### PR TITLE
Alerta: Add Customer in Alert Payload

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1998,6 +1998,8 @@ If the referenced key is not found in the match, it is replaced by the text indi
 
 ``alerta_value``: Defaults to "".
 
+``alerta_customer``: Defaults to rule's owner if defined otherwise None.
+
 The ``attributes`` dictionary is built by joining the lists from  ``alerta_attributes_keys`` and ``alerta_attributes_values``, considered in order.
 
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1827,7 +1827,7 @@ class AlertaAlerter(Alerter):
     def __init__(self, rule):
         super(AlertaAlerter, self).__init__(rule)
 
-        # Setup defaul parameters
+        # Setup default parameters
         self.url = self.rule.get('alerta_api_url', None)
         self.api_key = self.rule.get('alerta_api_key', None)
         self.timeout = self.rule.get('alerta_timeout', 86400)
@@ -1851,6 +1851,7 @@ class AlertaAlerter(Alerter):
         self.attributes_keys = self.rule.get('alerta_attributes_keys', [])
         self.attributes_values = self.rule.get('alerta_attributes_values', [])
         self.value = self.rule.get('alerta_value', '')
+        self.customer = self.rule.get('alerta_customer') or self.rule.get('owner', None)
 
     def alert(self, matches):
         # Override the resource if requested
@@ -1922,6 +1923,7 @@ class AlertaAlerter(Alerter):
             'attributes': dict(zip(self.attributes_keys,
                                    [resolve_string(a_value, match, self.missing_text) for a_value in self.attributes_values])),
             'rawData': self.create_alert_body([match]),
+            'customer': resolve_string(self.customer, match, self.missing_text),
         }
 
         try:

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -2010,7 +2010,8 @@ def test_alerta_no_auth(ea):
         "group": "Health",
         "attributes": {"senderIP": "1.1.1.1", "hostname": "<MISSING VALUE>", "TimestampEvent": "<MISSING VALUE>"},
         "type": "elastalert",
-        "event": "ProbeUP"
+        "event": "ProbeUP",
+        "customer": ""
     }
 
     mock_post_request.assert_called_once_with(
@@ -2107,7 +2108,8 @@ def test_alerta_new_style(ea):
         "group": "Health",
         "attributes": {"senderIP": "1.1.1.1", "hostname": "aProbe", "TimestampEvent": "<MISSING VALUE>"},
         "type": "elastalert",
-        "event": "ProbeUP"
+        "event": "ProbeUP",
+        "customer": ""
     }
 
     mock_post_request.assert_called_once_with(


### PR DESCRIPTION
Add customer key in Alerta alert payload derived from alerta_key in rule,
defaulting to customer if defined otherwise None